### PR TITLE
Add instance for single arguments

### DIFF
--- a/ReadArgs.hs
+++ b/ReadArgs.hs
@@ -126,6 +126,13 @@ instance (Argument a, ArgumentTuple y) => ArgumentTuple (a :& y) where
     return $ a :& y
   usageFor ~(a :& y) = " " ++ argName a  ++ usageFor y
 
+-- Use :& to derive an instance for single arguments
+instance (Argument a) => ArgumentTuple a where
+  parseArgsFrom ss = do
+    a :& () <- parseArgsFrom ss
+    return a
+  usageFor a = usageFor (a :& ())
+
 -- Use :& to derive instances for all the normal tuple types
 instance (Argument b, Argument a) => ArgumentTuple (b,a) where
   parseArgsFrom ss = do


### PR DESCRIPTION
As implemented by Adam Wagner: http://stackoverflow.com/a/8752683

No additional language pragmas were necessary, since ReadArgs.hs already uses Flexible, Undecidable, Overlapping Instances. I made sure that it cabal-dev installs still, but haven't performed any testing on the end product. Intuition says that Adam's testing should be relevant, but if you have a test suite you might want to run it through again just in case this screws up optional args or varargs or something. I can't imagine how it would, though.
